### PR TITLE
Migrations fixes

### DIFF
--- a/database/migrations/2021_10_23_081318_create_expense_table.php
+++ b/database/migrations/2021_10_23_081318_create_expense_table.php
@@ -20,7 +20,7 @@ class CreateExpenseTable extends Migration
              * Foreign key to expense_category table.
              */
             $table->unsignedBigInteger('expense_category_id');
-            $table->foreign('expense_category_id', 'fk_expense_expense_category')
+            $table->foreign('expense_category_id')
                 ->references('expense_category_id')->on('expense_category');
 
             $table->date('date');

--- a/database/migrations/2022_08_08_100418_update_expense_table_drop_old_columns.php
+++ b/database/migrations/2022_08_08_100418_update_expense_table_drop_old_columns.php
@@ -14,8 +14,8 @@ class UpdateExpenseTableDropOldColumns extends Migration
     public function up()
     {
         Schema::table('expense', function (Blueprint $table) {
-            $table->dropForeign('fk_expense_expense_category');
             $table->dropColumn('name');
+            $table->dropForeign(['expense_category_id']);
             $table->dropColumn('expense_category_id');
         });
     }


### PR DESCRIPTION
~~to reproduce this errosr:~~
- in `.env` file change `DB_CONNECTION=sqlite`
- create empty file: `database/database.sqlite`
- run `php artisan migration:fresh`. **WARNING:** this destroys the entire database.

<br>

---

~~**Error**: `SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.`~~

files: 
- `database/migrations/2022_08_08_100418_update_expense_table_drop_old_columns.php`
- `database/migrations/2023_01_04_164114_update_webpage_content_table.php`

<br>

---


~~**Error**: ` SQLite doesn't support dropping foreign keys (you would need to re-create the table).`~~

file: `database/migrations/2022_08_08_100418_update_expense_table_drop_old_columns.php`

<br>

---


~~**Error**: ` There is no column with name "title", "body", "image_path" on table "webpage_content".`~~

`->change()` is for chaning an existing column not for creating a new one.

file: `database/migrations/2023_02_13_181000_update_webpage_content_table_make_nullable.php~~