### PR TITLE
refactor: remove depecrated filter element and add coverage element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn-error.log
 /.idea
 /.vscode
 /stubs
+/phpunit/report

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,11 +12,16 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
+    <source>
+        <include>
+            <directory suffix=".php">app</directory>
+        </include>
+    </source>
+    <coverage>
+        <report>
+            <html outputDirectory="phpunit/report" />
+        </report>
+    </coverage>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>


### PR DESCRIPTION
@oitcode I was wondering if you want to merge this one, before open a new PR with tests. 

Basically I just removed the depecrated element `<filter>` from phpunit.xml and add `source` and `coverage` elements. 

link to docs: https://docs.phpunit.de/en/11.5/configuration.html

So now it's possible to get an html with the coverage report within phpunit/report which I added to gitignore, with this will be much easier for anyone check which tests are missing!

the command `php artisan test` will generate this report or if we want to see directly in the console we can run `./vendor/bin/phpunit --coverage-text`

link to [the command-line test runner](https://docs.phpunit.de/en/11.5/textui.html#command-line-options)

currently status of --coverage

![image](https://github.com/user-attachments/assets/cd48b6bd-1bb3-41b4-93e4-4b1b175db17f)

