### PR TITLE
Tests | SubscribeUs Component

### DIFF
--- a/app/Events/NewsletterSubscriptionCreated.php
+++ b/app/Events/NewsletterSubscriptionCreated.php
@@ -16,7 +16,7 @@ class NewsletterSubscriptionCreated
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $newsletterSubscription;
+    public NewsletterSubscription $newsletterSubscription;
 
     /**
      * Create a new event instance.
@@ -24,17 +24,5 @@ class NewsletterSubscriptionCreated
     public function __construct($newsletterSubscription)
     {
         $this->newsletterSubscription = $newsletterSubscription;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return array<int, \Illuminate\Broadcasting\Channel>
-     */
-    public function broadcastOn(): array
-    {
-        return [
-            new PrivateChannel('channel-name'),
-        ];
     }
 }

--- a/app/Livewire/EcommWebsite/SubscribeUs.php
+++ b/app/Livewire/EcommWebsite/SubscribeUs.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\EcommWebsite;
 
+use Illuminate\View\View;
 use Livewire\Component;
 use App\NewsletterSubscription;
 
@@ -9,16 +10,16 @@ use App\Events\NewsletterSubscriptionCreated;
 
 class SubscribeUs extends Component
 {
-    public $email;
+    public string $email;
 
-    public $introMessage = 'Please enter your email address to get regular updates on our products. ';
+    public string $introMessage = 'Please enter your email address to get regular updates on our products. ';
 
-    public function render()
+    public function render(): View
     {
         return view('livewire.ecomm-website.subscribe-us');
     }
 
-    public function store()
+    public function store(): void
     {
         $validatedData = $this->validate([
             'email' => 'required|email|unique:newsletter_subscription',
@@ -35,7 +36,7 @@ class SubscribeUs extends Component
         session()->flash('subscriptionMessage', 'Congratulations! Your subscription is added.');
     }
 
-    public function resetInputFields()
+    public function resetInputFields(): void
     {
         $this->email = '';
     }

--- a/app/NewsletterSubscription.php
+++ b/app/NewsletterSubscription.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class NewsletterSubscription extends Model
 {
+    use HasFactory;
+
     /**
      * The table associated with the model.
      *

--- a/database/factories/NewsletterSubscriptionFactory.php
+++ b/database/factories/NewsletterSubscriptionFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\NewsletterSubscription>
+ */
+class NewsletterSubscriptionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'email' => fake()->email(),
+        ];
+    }
+}

--- a/database/factories/NewsletterSubscriptionFactory.php
+++ b/database/factories/NewsletterSubscriptionFactory.php
@@ -18,6 +18,7 @@ class NewsletterSubscriptionFactory extends Factory
     {
         return [
             'email' => fake()->email(),
+            'status' => 'active'
         ];
     }
 }

--- a/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
+++ b/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
@@ -5,16 +5,13 @@ namespace Tests\Feature\Livewire\EcommWebsite;
 use App\Events\NewsletterSubscriptionCreated;
 use App\Livewire\EcommWebsite\SubscribeUs;
 use App\NewsletterSubscription;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use App\User;
 use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 use Tests\TestCase;
 
 class SubscribeUsTest extends TestCase
 {
-    Use RefreshDatabase;
-
     public function test_renders_sucessfully(): void
     {
         Livewire::test(SubscribeUs::class)
@@ -55,21 +52,25 @@ class SubscribeUsTest extends TestCase
 
     public function test_subscription_succeeds_when_email_is_provided(): void
     {
+        $user = User::factory()->create();
+
         Livewire::test(SubscribeUs::class)
-            ->set('email', 'johndoe@example.com')
+            ->set('email', $user->email)
             ->call('store')
             ->assertHasNoErrors()
             ->assertSee('Congratulations! Your subscription is added.');
 
         $this->assertDatabaseHas('newsletter_subscription', [
-            'email' => 'johndoe@example.com',
+            'email' => $user->email,
         ]);
     }
 
     public function test_fields_are_reset_after_subscribing_to_the_newsletter(): void
     {
+        $user = User::factory()->create();
+
         Livewire::test(SubscribeUs::class)
-            ->set('email', 'johndoe@example.com')
+            ->set('email', $user->email)
             ->call('store')
             ->assertHasNoErrors()
             ->assertSet('email', '');
@@ -77,10 +78,12 @@ class SubscribeUsTest extends TestCase
 
     public function test_event_is_dispatched_when_subscription_succeeds(): void
     {
+        $user = User::factory()->create();
+
         Event::fake();
 
         Livewire::test(SubscribeUs::class)
-            ->set('email', 'johndoe@example.com')
+            ->set('email', $user->email)
             ->call('store')
             ->assertHasNoErrors();
 

--- a/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
+++ b/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
@@ -4,9 +4,11 @@ namespace Tests\Feature\Livewire\EcommWebsite;
 
 use App\Events\NewsletterSubscriptionCreated;
 use App\Livewire\EcommWebsite\SubscribeUs;
+use App\Mail\NewsletterSubscriptionCreatedNotificationEmail;
 use App\NewsletterSubscription;
 use App\User;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -99,5 +101,19 @@ class SubscribeUsTest extends TestCase
             ->assertHasErrors(['email']);
 
         Event::assertNotDispatched(NewsletterSubscriptionCreated::class);
+    }
+
+    public function test_email_is_sent_when_subscription_succeeds(): void
+    {
+        $user = User::factory()->create();
+
+        Mail::fake();
+
+        Livewire::test(SubscribeUs::class)
+            ->set('email', $user->email)
+            ->call('store')
+            ->assertHasNoErrors();
+
+        Mail::assertSent(NewsletterSubscriptionCreatedNotificationEmail::class);
     }
 }

--- a/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
+++ b/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
@@ -87,7 +87,7 @@ class SubscribeUsTest extends TestCase
         Event::assertDispatched(NewsletterSubscriptionCreated::class);
     }
 
-    public function test_event_is__not_dispatched_when_subscription_fails(): void
+    public function test_event_is_not_dispatched_when_subscription_fails(): void
     {
         Event::fake();
 

--- a/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
+++ b/tests/Feature/Livewire/EcommWebsite/SubscribeUsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Livewire\EcommWebsite;
+
+use App\Events\NewsletterSubscriptionCreated;
+use App\Livewire\EcommWebsite\SubscribeUs;
+use App\NewsletterSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Event;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SubscribeUsTest extends TestCase
+{
+    Use RefreshDatabase;
+
+    public function test_renders_sucessfully(): void
+    {
+        Livewire::test(SubscribeUs::class)
+            ->assertStatus(200);
+    }
+
+    public function test_displays_intro_message(): void
+    {
+        Livewire::test(SubscribeUs::class)
+            ->assertSee('Please enter your email address to get regular updates on our products. ');
+    }
+
+    public function test_can_reset_input_fields(): void
+    {
+        Livewire::test(SubscribeUs::class)
+            ->set('email', 'johndoe@example.com')
+            ->assertSet('email', 'johndoe@example.com')
+            ->call('resetInputFields')
+            ->assertSet('email', '');
+    }
+
+    public function test_subscription_fails_when_email_is_missing(): void
+    {
+        Livewire::test(SubscribeUs::class)
+            ->call('store')
+            ->assertHasErrors(['email']);
+    }
+
+    public function test_subscription_fails_if_email_is_already_subscribed(): void
+    {
+        $olderSubscription = NewsletterSubscription::factory()->create();
+
+        Livewire::test(SubscribeUs::class)
+            ->set('email', $olderSubscription->email)
+            ->call('store')
+            ->assertHasErrors(['email']);
+    }
+
+    public function test_subscription_succeeds_when_email_is_provided(): void
+    {
+        Livewire::test(SubscribeUs::class)
+            ->set('email', 'johndoe@example.com')
+            ->call('store')
+            ->assertHasNoErrors()
+            ->assertSee('Congratulations! Your subscription is added.');
+
+        $this->assertDatabaseHas('newsletter_subscription', [
+            'email' => 'johndoe@example.com',
+        ]);
+    }
+
+    public function test_fields_are_reset_after_subscribing_to_the_newsletter(): void
+    {
+        Livewire::test(SubscribeUs::class)
+            ->set('email', 'johndoe@example.com')
+            ->call('store')
+            ->assertHasNoErrors()
+            ->assertSet('email', '');
+    }
+
+    public function test_event_is_dispatched_when_subscription_succeeds(): void
+    {
+        Event::fake();
+
+        Livewire::test(SubscribeUs::class)
+            ->set('email', 'johndoe@example.com')
+            ->call('store')
+            ->assertHasNoErrors();
+
+        Event::assertDispatched(NewsletterSubscriptionCreated::class);
+    }
+
+    public function test_event_is__not_dispatched_when_subscription_fails(): void
+    {
+        Event::fake();
+
+        Livewire::test(SubscribeUs::class)
+            ->call('store')
+            ->assertHasErrors(['email']);
+
+        Event::assertNotDispatched(NewsletterSubscriptionCreated::class);
+    }
+}


### PR DESCRIPTION
### Context

To finish the Listeners & events tests, I started by SubscribeUs Livewire component. 

### What I've done

- Created a NewsletterSubscription Factory to help with tests.
- Create test for SubscribeUs component.
- Remove NewsletterSubscriptionCreated `broadcastOn` method, since we are not using any special channel for this one.
- Refactor SubscribeUs & NewsletterSubscriptionCreated to have types & return types.


With this we already cover 100% for Events & Listeners
![image](https://github.com/user-attachments/assets/51416be7-ba1a-40ba-b2ab-3f473b73c55d)

About SubscribeUs
![image](https://github.com/user-attachments/assets/3c2e0218-de38-4b09-ad64-a4b6cc37fb5c)
