### PR TITLE
Feat: Add delete user functionality

### DIFF
--- a/app/Livewire/User/UserList.php
+++ b/app/Livewire/User/UserList.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\User;
 
+use Illuminate\Http\Request;
 use Livewire\Component;
 use Illuminate\View\View;
 use Livewire\WithPagination;
@@ -49,10 +50,21 @@ class UserList extends Component
         $this->exitMode('delete');
     }
 
-    public function confirmDeleteUser(): void
+    public function confirmDeleteUser(Request $request): void
     {
-        // Todo: Add delete functionality later.
-        //       For now we cannot delete user!
+        if ($request->user()->cannot('delete', $this->deletingUser)) {
+            session()->flash('error', 'ERROR! Admin users cannot be deleted.');
+            $this->exitMode('delete');
+            return;
+        }
+
+        try {
+            $this->deletingUser->delete();
+            session()->flash('success', "SUCCESS! User: {$this->deletingUser?->name} deleted successfully.");
+        } catch (\Exception $e) {
+            session()->flash('error', 'ERROR! Something went wrong, please try again later.');
+        }
+
         $this->exitMode('delete');
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use Illuminate\Auth\Access\Response;
+
+class UserPolicy
+{
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, User $model): bool
+    {
+        if ($model->role === 'admin' || $user->role !== 'admin') {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/View/Components/AlertComponent.php
+++ b/app/View/Components/AlertComponent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class AlertComponent extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        public string $type,
+        public string $message,
+    ){}
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.alert-component');
+    }
+}

--- a/resources/views/components/alert-component.blade.php
+++ b/resources/views/components/alert-component.blade.php
@@ -1,0 +1,8 @@
+<div>
+    <div class="alert alert-{{$type}} alert-dismissible fade show" role="alert">
+        {{ $message }}
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+</div>

--- a/resources/views/livewire/user/user-list.blade.php
+++ b/resources/views/livewire/user/user-list.blade.php
@@ -1,5 +1,13 @@
 <div>
 
+  @session('error')
+    <x-alert-component id="alert-error" type="danger" :message="session('error')" />
+  @endsession
+
+  @session('success')
+    <x-alert-component id="alert-success" type="success" :message="session('success')" />
+  @endsession
+
   <x-list-component>
     <x-slot name="listInfo">
       <div class="d-flex">

--- a/tests/Feature/Livewire/User/UserListTest.php
+++ b/tests/Feature/Livewire/User/UserListTest.php
@@ -30,12 +30,45 @@ class UserListTest extends TestCase
 
     public function test_exit_user_delete_mode_false_on_confirm_delete_user(): void
     {
-        $user = User::where('role', 'admin')->first();
+        $adminUsers = User::where('role', 'admin')->take(2)->get();
 
-        Livewire::test(UserList::class)
-            ->call('deleteUser', $user)
+        Livewire::actingAs($adminUsers[0])
+            ->test(UserList::class)
+            ->call('deleteUser', $adminUsers[1])
             ->assertSet('modes.delete', true)
             ->call('confirmDeleteUser')
+            ->assertSet('modes.delete', false);
+    }
+
+    public function test_is_not_possible_to_delete_admin_users()
+    {
+        $adminUsers = User::where('role', 'admin')->take(2)->get();
+
+        Livewire::actingAs($adminUsers[0])
+            ->test(UserList::class)
+            ->call('deleteUser', $adminUsers[1])
+            ->assertSet('modes.delete', true)
+            ->call('confirmDeleteUser')
+            ->assertSeeText('ERROR! Admin users cannot be deleted.')
+            ->assertSet('modes.delete', false);
+    }
+
+    public function test_admin_users_can_delete_standard_users()
+    {
+        $admin = User::where('role', 'admin')->first();
+        $standard = User::create([
+            'name' => 'Standard User',
+            'email' => 'standarduser@example.com',
+            'role' => 'standard',
+            'password' => 'password'
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(UserList::class)
+            ->call('deleteUser', $standard)
+            ->assertSet('modes.delete', true)
+            ->call('confirmDeleteUser')
+            ->assertSeeText("SUCCESS! User: {$standard->name} deleted successfully.")
             ->assertSet('modes.delete', false);
     }
 }


### PR DESCRIPTION
@oitcode finally got some time to work on this. 

1. Policy to check deleted user && auth user.
      - Deleted user can not be admin.
      - Auth user must be admin.
2. Alert component with type & message so we can use it for success & error.
3. Return session with error or success to show the alert. 
4. Add respective tests. 

Please take a look, feel free to ask me changes. 